### PR TITLE
Version Upgrade [wagon-http-lightweight, jackson-core, github-api, maven-compat, jarchivelib, aether-impl, plexus-utils]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,10 +20,10 @@
     <java.version>1.8</java.version>
     <project.build.jdkVersion>1.8</project.build.jdkVersion>
     <groupbyinc.api.version>2.2.72</groupbyinc.api.version>
-    <mavenVersion>3.0.3</mavenVersion>
-    <wagonVersion>1.0-beta-7</wagonVersion>
-    <aetherVersion>1.11</aetherVersion>
-    <jackson.version>2.6.3</jackson.version>
+    <mavenVersion>3.0.5</mavenVersion>
+    <wagonVersion>1.0</wagonVersion>
+    <aetherVersion>1.13.1</aetherVersion>
+    <jackson.version>2.6.7</jackson.version>
   </properties>
   <dependencies>
 
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>org.rauschig</groupId>
       <artifactId>jarchivelib</artifactId>
-      <version>0.7.0</version>
+      <version>0.7.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -140,7 +140,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>2.0.6</version>
+      <version>2.0.7</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -170,7 +170,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
-      <version>1.75</version>
+      <version>1.76</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Library Upgrade
- ✓ `org.apache.maven.wagon:wagon-http-lightweight:1.0-beta-7 -->  1.0`
- ✓ `com.fasterxml.jackson.core:jackson-core:2.6.3 -->  2.6.7`
- ✓ `org.kohsuke:github-api:1.75 -->  1.76`
- ✓ `org.apache.maven:maven-compat:3.0.3 -->  3.0.5`
- ? `com.fasterxml.jackson.core:jackson-databind:2.6.3 -->  2.6.7`
- ✓ `org.rauschig:jarchivelib:0.7.0 -->  0.7.1`
- ✓ `org.sonatype.aether:aether-impl:1.11 -->  1.13.1`
- ? `org.sonatype.aether:aether-connector-file:1.11 -->  1.13.1`
- ✓ `org.codehaus.plexus:plexus-utils:2.0.6 -->  2.0.7`
- ? `org.sonatype.aether:aether-api:1.11 -->  1.13.1`
- ? `org.sonatype.aether:aether-connector-wagon:1.11 -->  1.13.1`

---

Upgrade brought to you by GroupBy <a href="https://github.com/groupby/dependency-checker">dependency-checker</a>
